### PR TITLE
Fix async wallet generation

### DIFF
--- a/app/api/trading.py
+++ b/app/api/trading.py
@@ -171,7 +171,8 @@ async def gen_wallet():
     '''
     # ETH 입금주소 생성 GET https://api.hyperunit.xyz/gen/ethereum/hyperliquid/eth/0xYourHLAddress
     url = f"{settings.HYPERUNIT_API_URL}/gen/ethereum/hyperliquid/eth/{account.address}"
-    response = httpx.get(url)
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url)
     response.raise_for_status()
     '''
     ETH: {
@@ -213,7 +214,8 @@ async def gen_wallet():
 
     # SOL 입금 주소 생성 GET https://api.hyperunit.xyz/gen/solana/hyperliquid/sol/0xYourHLAddress
     url = f"{settings.HYPERUNIT_API_URL}/gen/solana/hyperliquid/sol/{account.address}"
-    response = httpx.get(url)
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url)
     response.raise_for_status()
     sol_data = response.json()
     print(f"SOL deposit address generated: {sol_data['address']}")

--- a/tests/test_trading.py
+++ b/tests/test_trading.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 import base64
 import time
 from app.main import app
@@ -162,7 +162,7 @@ def test_wallet_balance_invalid_address():
 
 
 # gen_wallet 함수 테스트
-@patch('httpx.get')
+@patch('httpx.AsyncClient.get', new_callable=AsyncMock)
 def test_gen_wallet_success(mock_get):
     """지갑 생성 성공 테스트"""
     # Mock 설정


### PR DESCRIPTION
## Summary
- use `AsyncClient` for wallet generation endpoints
- update wallet generation test to patch async call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'eth_keys')*

------
https://chatgpt.com/codex/tasks/task_e_68775ca229b483269d6330b6af05c3a0